### PR TITLE
🐛 Fix double slash in url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.1] - 2021-04-13
+### Fixed
+- Fix double slash in final url when no modificator used
+
+## [2.0.0] - 2021-04-13
+### Changed
+- Migration from jCenter to Maven Central 🎉
+- ‼️ Important ‼️ groupId has changed. New groupId is `io.github.ackeecz`.
+- Package name changed as well from `cz.ackee.resizin` to `io.github.ackeecz.resizin.sdk`

--- a/sdk/src/main/java/io/github/ackeecz/resizin/sdk/Resizin.kt
+++ b/sdk/src/main/java/io/github/ackeecz/resizin/sdk/Resizin.kt
@@ -1,7 +1,6 @@
 package io.github.ackeecz.resizin.sdk
 
 import androidx.annotation.VisibleForTesting
-import java.util.ArrayList
 import java.util.Locale
 
 /**
@@ -227,14 +226,28 @@ class Resizin(private val appId: String) {
          */
         @JvmOverloads
         fun generate(imageId: String? = this.imageId): String {
-            val builder = StringBuilder(this.serverUrl)
-            if (!this.serverUrl.endsWith("/")) {
-                builder.append("/")
+            return buildString {
+                append(serverUrl)
+                if (!serverUrl.endsWith("/")) {
+                    append("/")
+                }
+                append(appId).append("/")
+                append("image").append("/")
+                val transformations = createTransformations()
+                append(transformations.filter { it.isNotEmpty() }.joinToString("-"))
+                if (transformations.isNotEmpty()) {
+                    append("/")
+                }
+                append(imageId)
+                if (!extension.isNullOrEmpty()) {
+                    append(".").append(extension)
+                }
             }
+        }
 
-            builder.append(this.appId).append("/")
-            builder.append("image").append("/")
-            val transformations = ArrayList<String>()
+        private fun createTransformations(): List<String> {
+            val transformations = mutableListOf<String>()
+
             if (this.widthSet) {
                 transformations.add(String.format(Locale.US, "w_%d", this.width))
             }
@@ -254,37 +267,24 @@ class Resizin(private val appId: String) {
             if (this.grayscale) {
                 transformations.add("f_greyscale")
             }
+
             if (quality >= 0) {
                 transformations.add(String.format(Locale.US, "q_%d", this.quality))
             }
+
             if (upscale >= 0) {
                 transformations.add(String.format(Locale.US, "u_%d", this.upscale))
             }
+
             if (borderTop >= 0 && borderLeft >= 0 && borderRight >= 0 && borderBottom >= 0) {
                 transformations.add(String.format(Locale.US, "b_%d_%d_%d_%d", borderTop, borderLeft, borderRight, borderBottom))
             }
+
             if (background != null) {
                 transformations.add(String.format(Locale.US, "bg_%s", background))
             }
 
-            builder.append(this.join("-", transformations))
-            builder.append("/")
-            builder.append(imageId)
-            if (this.extension != null && this.extension!!.length > 0) {
-                builder.append(".").append(extension)
-            }
-            return builder.toString()
-        }
-
-        private fun join(delimiter: String, transformations: List<String>): String {
-            val builder = StringBuilder()
-            for (operation in transformations) {
-                if (builder.isNotEmpty()) {
-                    builder.append(delimiter)
-                }
-                builder.append(operation)
-            }
-            return builder.toString()
+            return transformations
         }
 
         internal fun parseUrl(url: String): UrlGenerator {

--- a/sdk/src/test/java/io/github/ackeecz/resizin/sdk/FinalUrlTests.kt
+++ b/sdk/src/test/java/io/github/ackeecz/resizin/sdk/FinalUrlTests.kt
@@ -1,0 +1,30 @@
+package io.github.ackeecz.resizin.sdk
+
+import junit.framework.Assert.assertEquals
+import org.junit.Test
+
+class FinalUrlTests {
+
+    @Test
+    fun `should have correct urls without modifiers`() {
+        // arrange
+        val resizin = Resizin("appid")
+        // act
+        val url = resizin.url().generate(imageId = "img")
+        // assert
+        assertEquals("https://img.resizin.com/appid/image/img", url)
+    }
+
+    @Test
+    fun `should have correct format with specified width and height`() {
+        // arrange
+        val resizin = Resizin("appid")
+        // act
+        val url = resizin.url()
+            .width(100)
+            .height(100)
+            .generate(imageId = "img")
+        // assert
+        assertEquals("https://img.resizin.com/appid/image/w_100-h_100/img", url)
+    }
+}

--- a/sdk/src/test/java/io/github/ackeecz/resizin/sdk/ParsingTests.kt
+++ b/sdk/src/test/java/io/github/ackeecz/resizin/sdk/ParsingTests.kt
@@ -1,7 +1,5 @@
 package io.github.ackeecz.resizin.sdk
 
-import io.github.ackeecz.resizin.sdk.Crop
-import io.github.ackeecz.resizin.sdk.Gravity
 import org.junit.Assert.assertEquals
 import org.junit.Test
 


### PR DESCRIPTION
When no modificators were used on the
url builder then there was a double slash
in the final url and the image server did not
serve that image.

Related: #58056